### PR TITLE
Updates from sprintf() to snprintf().

### DIFF
--- a/core/parser.h
+++ b/core/parser.h
@@ -191,8 +191,8 @@ void ceval_print_node(const ceval_node * node, int indent) {
     ceval_print_node(node -> right, indent + 4);
     if (node -> id == CEVAL_NUMBER) {
         if ((long) node -> number == node -> number) //for integers, skip the trailing zeroes
-            sprintf(number, "%.0f", node -> number);
-        else sprintf(number, "%.2f", node -> number);
+            snprintf(number, sizeof(number), "%.0f", node -> number);
+        else snprintf(number, sizeof(number), "%.2f", node -> number);
         str = number;
     } else {
         str = ceval_token_symbol(node -> id);


### PR DESCRIPTION
Xcode 14 has marked sprintf() as deprecated, with a note to move to snprintf() instead.